### PR TITLE
avoid crash in receiveRequest

### DIFF
--- a/lib/src/ua.dart
+++ b/lib/src/ua.dart
@@ -733,7 +733,11 @@ class UA extends EventManager {
           _findDialog(request.call_id!, request.from_tag!, request.to_tag!);
 
       if (dialog != null) {
-        dialog.receiveRequest(request);
+        try {
+          dialog.receiveRequest(request);
+        } catch (e) {
+          logger.e('Error: failed to handle request. ${e.toString()}');
+        }
       } else if (method == SipMethod.NOTIFY) {
         Subscriber? sub = _findSubscriber(
             request.call_id!, request.from_tag!, request.to_tag!);


### PR DESCRIPTION
The below exception raises in race condition and it crashes the App. This code catch the exception and avoid crash.

```
Assertion failed: "Invalid reason_phrase: Wrong Status”
```