### PR TITLE
Add sendInterval to dtmf

### DIFF
--- a/lib/src/rtc_session.dart
+++ b/lib/src/rtc_session.dart
@@ -848,6 +848,7 @@ class RTCSession extends EventManager implements Owner {
     int duration = options['duration'] ?? RTCSession_DTMF.C.DEFAULT_DURATION;
     int interToneGap =
         options['interToneGap'] ?? RTCSession_DTMF.C.DEFAULT_INTER_TONE_GAP;
+    int sendInterval = options['sendInterval'] ?? duration + interToneGap;
 
     if (tones == null) {
       throw Exceptions.TypeError('Not enough arguments');
@@ -931,7 +932,7 @@ class RTCSession extends EventManager implements Owner {
 
           dtmf.send(tone, options);
           await Future<void>.delayed(
-              Duration(milliseconds: duration + interToneGap), () {});
+              Duration(milliseconds: sendInterval), () {});
         });
       }
     }


### PR DESCRIPTION
This change will allows user to control the sending interval by `sendInterval` option.
For users who are using SIP INFO DTMF, waiting `duration + interToneGap` is not nessesary.
